### PR TITLE
Fix container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,13 @@ RUN apt update && apt dist-upgrade -y && apt clean
 RUN apt update \
     && apt install -y \
     python3-pip \
+    python3-dev \
+    gcc \
+    g++ \
     python3-requests \
     python3-daemon \
     python3-toml \
+    python3-wheel \
     bwm-ng \
     sysstat \
     tcpdump \
@@ -50,6 +54,8 @@ COPY helpers/cadrhelpers/node_context.py /usr/local/sbin/node_context
 
 # install python package for dependencies
 COPY helpers /root/helpers
+
+RUN pip3 install wheel
 RUN pip3 install /root/helpers
 
 COPY . /dtn_routing


### PR DESCRIPTION
This commit fixes bunch of errors with building rapidjson

example of errors:

```shell
./rapidjson.cpp:11:10: fatal error: Python.h: No such file or directory
   #include <Python.h>
            ^~~~~~~~~~
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for python-rapidjson

```